### PR TITLE
Update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is the starting point for joining and contributing to the Battlesnake commu
 
 Each of the folders marked `repo_***` are descriptions of each of the active repositories that we manage and who the owners are.
 
+Documentation is available at http://docs.battlesnake.io
+
 ## Code of Conduct
 
 The Battlesnake community abides by the [CNCF code of conduct].  Here is an excerpt:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Available at http://docs.battlesnake.io

--- a/repo-docs/README.md
+++ b/repo-docs/README.md
@@ -1,7 +1,7 @@
 Docs
 ===
 
-This repository holds all of the docs that get generated and live at http://battlesnake.io/docs
+This repository holds all of the docs that get generated and live at http://docs.battlesnake.io
 
 ## Owners
 


### PR DESCRIPTION
Many external links (https://battlesnake.io, https://github.com/sendwithus/battlesnake) funnel people to this repo; this commit makes it a little easier for those people to find the documentation from here.