### PR TITLE
Consolidate repo information into one file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Battlesnake community!
 
 This is the starting point for joining and contributing to the Battlesnake community - improving docs, improving code, competing etc.
 
-Each of the folders marked `repo_***` are descriptions of each of the active repositories that we manage and who the owners are.
+`repo.md` contains descriptions of each of the active repositories that we manage and who the owners are.
 
 Documentation is available at http://docs.battlesnake.io
 

--- a/repo-board/README.md
+++ b/repo-board/README.md
@@ -1,8 +1,0 @@
-Board
-===
-
-The visualization of the Battlesnake games.
-
-## Owners
-
-- jem/rob/tristan

--- a/repo-branding/README.md
+++ b/repo-branding/README.md
@@ -1,8 +1,0 @@
-Branding
-===
-
-All of the media content for Battlesnake.
-
-## Owners
-
-- [bvanvugt](https://github.com/bvanvugt)

--- a/repo-community/README.md
+++ b/repo-community/README.md
@@ -1,9 +1,0 @@
-Community
-===
-
-This repo!  Go read the README.md in the root of this project.
-
-## Owners
-
-- [@bvanvugt](https://github.com/bvanvugt)
-- [@codeallthethingz](https://github.com/codeallthethingz)

--- a/repo-docs/README.md
+++ b/repo-docs/README.md
@@ -1,8 +1,0 @@
-Docs
-===
-
-This repository holds all of the docs that get generated and live at http://docs.battlesnake.io
-
-## Owners
-
-- [@codeallthethingz](https://github.com/codeallthethingz)

--- a/repo-engine/README.md
+++ b/repo-engine/README.md
@@ -1,9 +1,0 @@
-Engine
-===
-
-The Battlesnake game engine.  It is here that all the snakes fight each other.
-
-## Owners
-
-- [@dlsteuer](https://github.com/dlsteuer)
-- [@ColDog](https://github.com/orgs/battlesnakeio/people/ColDog)

--- a/repo-play/README.md
+++ b/repo-play/README.md
@@ -1,9 +1,0 @@
-Play
-====
-
-leader board, where to view games.
-
-## Owners
-
-- [@brandonb927](https://github.com/brandonb927)
-- [@joram](https://github.com/joram)

--- a/repo-roadmap/README.md
+++ b/repo-roadmap/README.md
@@ -1,9 +1,0 @@
-Roadmap
-===
-
-A repository for just the issues / features / ideas / bugs and suggestions to add to the Battlesnake experience.
-
-## Owners
-
-- [@bvanvugt](https://github.com/bvanvugt)
-- [@codeallthethingz](https://github.com/codeallthethingz)

--- a/repo-starter-snake-node/README.md
+++ b/repo-starter-snake-node/README.md
@@ -1,8 +1,0 @@
-Starter Snake Node
-===
-
-A snake server written in node.
-
-## Owners
-
-- [@brandonb927](https://github.com/brandonb927)

--- a/repo-website/README.md
+++ b/repo-website/README.md
@@ -1,4 +1,0 @@
-Website
-===
-
-Currently not in use.

--- a/repos.md
+++ b/repos.md
@@ -1,0 +1,123 @@
+# Repositories
+
+Descriptions of the active repositories that we manage and who the owners are.
+
+
+## [Board](https://github.com/battlesnakeio/board)
+
+The visualization of the Battlesnake games.
+
+### Owners
+
+- jem/rob/tristan
+
+
+## [Branding](https://github.com/battlesnakeio/branding)
+
+All of the media content for Battlesnake.
+Not currently in use.
+
+### Owners
+
+- [bvanvugt](https://github.com/bvanvugt)
+
+
+## [Community](https://github.com/weslord/community)
+
+This repo!  Go read the README.md in the root of this project.
+
+https://github.com/battlesnakeio/community
+
+### Owners
+
+- [@bvanvugt](https://github.com/bvanvugt)
+- [@codeallthethingz](https://github.com/codeallthethingz)
+
+
+## [Docs](https://github.com/battlesnakeio/docs)
+
+This repository holds all of the docs that get generated and live at http://docs.battlesnake.io
+
+### Owners
+
+- [@codeallthethingz](https://github.com/codeallthethingz)
+
+
+## [Engine](https://github.com/battlesnakeio/engine)
+
+The Battlesnake game engine.  It is here that all the snakes fight each other.
+
+### Owners
+
+- [@dlsteuer](https://github.com/dlsteuer)
+- [@ColDog](https://github.com/orgs/battlesnakeio/people/ColDog)
+
+
+## [Infrastructure](https://github.com/battlesnakeio/infrastructure)
+
+The Battlesnake infrastructure is designed around Google Cloud Platform, Terraform, Kubernetes and Docker.
+
+### Owners
+
+ - 
+
+
+## [Play](https://github.com/battlesnakeio/play)
+
+Leader board, where to view games.
+
+### Owners
+
+- [@brandonb927](https://github.com/brandonb927)
+- [@joram](https://github.com/joram)
+
+
+## [Roadmap](https://github.com/battlesnakeio/roadmap)
+
+A repository for just the issues / features / ideas / bugs and suggestions to add to the Battlesnake experience.
+
+### Owners
+
+- [@bvanvugt](https://github.com/bvanvugt)
+- [@codeallthethingz](https://github.com/codeallthethingz)
+
+
+## [Starter Snake Go](https://github.com/battlesnakeio/starter-snake-go)
+
+A snake server written in Go.
+
+### Owners
+
+ - 
+
+
+## [Starter Snake Java](https://github.com/battlesnakeio/starter-snake-java)
+
+A snake server written in Java
+
+### Owners
+
+ - 
+
+
+## [Starter Snake Node](https://github.com/battlesnakeio/starter-snake-node)
+
+A snake server written in node.
+
+### Owners
+
+- [@brandonb927](https://github.com/brandonb927)
+
+
+## [Starter Snake Python](https://github.com/battlesnakeio/starter-snake-python)
+
+A snake server written in Python.
+
+### Owners
+
+ - 
+
+
+## [Website](https://github.com/battlesnakeio/website)
+
+Currently not in use.


### PR DESCRIPTION
- Moved all the repo information from multiple directories to one file that is easier to review at-a-glance.
- Added links to each repository for more direct navigation.
- Added missing infrastructure and starter snake repos

This is mainly a change to how this information is organized. I have not included ownership information for the newly added repos or verified that the existing listed owners are correct.

If I've overlooked a good reason to keep the old structure, let me know and I will update the links and add missing repos using the /repo-*/README.md style instead.